### PR TITLE
Gitignore code-context.md to eliminate merge conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Claude Code skill that generates a persistent `code-context.md` for your proje
 **Why use it:**
 - Eliminates cold-start exploration — Claude knows your codebase immediately
 - Auto-updates when your code changes — tracks a git hash marker, detects drift, and updates itself
-- Team-friendly — one developer runs `init` and commits `code-context.md`, everyone else gets instant context and only incremental updates from there
+- Conflict-free — `code-context.md` is gitignored and generated per developer, so concurrent work on shared branches never produces merge conflicts on it
 
 ## Install
 
@@ -66,12 +66,15 @@ The skill adapts to your tech stack:
 
 ## Permissions and File Changes
 
-This skill touches exactly **two files** in your project root. Nothing else.
+This skill touches exactly **three files** in your project root. Nothing else.
 
 | File | Action | When |
 |------|--------|------|
 | `code-context.md` | Created / edited | `init`, `update`, or auto-update on session start |
 | `CLAUDE.md` | Created / appended / section removed | `init` adds a section, `uninstall` removes it |
+| `.gitignore` | Created / appended | `init` ensures `code-context.md` is listed |
+
+On `init`, if `code-context.md` was previously tracked in git, the skill runs `git rm --cached code-context.md` to untrack it (the working-tree file is preserved) and warns you to commit the `.gitignore` change so teammates stop pulling it.
 
 It only **reads** your source files — never modifies source code, configs, or any other project files.
 
@@ -82,6 +85,7 @@ It only **reads** your source files — never modifies source code, configs, or 
 - Does not make git commits or push to remote
 - Does not access the network or external APIs
 - Does not delete any files (uninstall leaves `code-context.md` in place)
+- Does not stage or commit `code-context.md` — it is gitignored and stays per-developer
 
 ## Philosophy
 

--- a/skills/code-context/SKILL.md
+++ b/skills/code-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-context
 description: Generate and maintain a comprehensive code-context.md file that captures deep codebase understanding — models, routes, components, stores, architecture, data flows, and key patterns. Commands - init, update, uninstall.
-allowed-tools: Agent Bash(ls *) Bash(git diff *) Bash(git log *) Bash(git rev-parse *) Bash(rm -rf *) Glob Grep Read Write Edit
+allowed-tools: Agent Bash(ls *) Bash(git diff *) Bash(git log *) Bash(git rev-parse *) Bash(git ls-files *) Bash(git rm --cached *) Bash(rm -rf *) Glob Grep Read Write Edit
 argument-hint: "<init|update|uninstall> [optional focus area or description]"
 effort: high
 ---
@@ -113,7 +113,25 @@ Write the file to `code-context.md` in the project root with this structure:
 
 **The `<!-- code-context-marker: ... -->` HTML comment is critical.** It stores the git commit hash at the time of generation. This marker enables automatic change detection — at the start of future sessions, Claude compares this hash against the current HEAD to determine if the codebase has changed and the context needs updating.
 
-### Step 4: Set up CLAUDE.md for auto-maintenance
+**Do not stage or commit `code-context.md`.** The file is per-developer state and is kept out of version control (see Step 4 below). The skill must never run `git add code-context.md` or create a commit for it.
+
+### Step 4: Ensure code-context.md is gitignored
+
+`code-context.md` is auto-generated per developer and every Claude session may rewrite it with slightly different content. Committing it produces repeated merge conflicts on shared branches, so the skill keeps it out of version control.
+
+1. **Ensure `.gitignore` lists `code-context.md`:**
+   - If `.gitignore` does not exist at the project root, create it with a single line: `code-context.md`
+   - If `.gitignore` exists, read it. If it already contains `code-context.md` as its own line (exact match, ignoring leading/trailing whitespace), do nothing.
+   - Otherwise, append `code-context.md` on a new line. Preserve the existing file contents and trailing newline convention.
+
+2. **Untrack the file if it was previously committed:**
+   - Run `git ls-files --error-unmatch code-context.md` to check if it is tracked.
+   - If tracked (command exits 0), run `git rm --cached code-context.md`. This removes it from the index without deleting the working-tree file.
+   - If untracked (command exits non-zero), skip this step silently.
+
+3. **If `git rm --cached` ran, warn the user** that they must commit the untracking so other team members stop pulling the file: "I untracked `code-context.md` from git. Commit this change (`git add .gitignore && git commit -m 'gitignore code-context.md'`) so other team members stop receiving the file on pull."
+
+### Step 5: Set up CLAUDE.md for auto-maintenance
 
 After generating `code-context.md`, ensure the project's `CLAUDE.md` has instructions for Claude to read and maintain it. This is what makes the system self-sustaining.
 
@@ -158,11 +176,12 @@ defeat the purpose of the file.
 
 Tell the user:
 1. `code-context.md` has been generated at the project root
-2. `CLAUDE.md` has been set up (or updated) to auto-read and auto-maintain the context file
-3. The context file includes a git hash marker for automatic change detection
-4. From now on, every Claude session will check for codebase changes and auto-update if needed
-5. They can run `/code-context update` manually after large refactors
-6. Suggest they review the file and flag any inaccuracies or missing areas
+2. `code-context.md` has been added to `.gitignore` (and untracked from git if it was previously committed — flag this separately and remind them to commit the `.gitignore` change)
+3. `CLAUDE.md` has been set up (or updated) to auto-read and auto-maintain the context file
+4. The context file includes a git hash marker for automatic change detection
+5. From now on, every Claude session will check for codebase changes and auto-update if needed
+6. They can run `/code-context update` manually after large refactors
+7. Suggest they review the file and flag any inaccuracies or missing areas
 
 ---
 


### PR DESCRIPTION
Closes #1

## Summary
- `init` now ensures `code-context.md` is present in `.gitignore` (creating the file if missing, idempotently appending if not listed) and runs `git rm --cached code-context.md` if the file was previously committed — with a user-facing warning to commit the untracking
- `SKILL.md` documents explicitly that the skill must never stage or commit `code-context.md`; `allowed-tools` frontmatter extended with `Bash(git ls-files *)` and `Bash(git rm --cached *)`
- `README.md` replaces the "one-dev-commits, team-pulls" framing with a conflict-free per-developer model; file-changes table now shows `.gitignore`

## Acceptance Criteria Verified
- **`.gitignore` idempotent add** — new Step 4 in `SKILL.md` creates the file if missing, exact-line match check before appending
- **Untrack previously-committed file** — `git ls-files --error-unmatch` probe, then `git rm --cached` with an explicit user warning
- **Never stages or commits `code-context.md`** — explicit prohibition added after Step 3 in `SKILL.md`; `allowed-tools` does not include `git add` or `git commit`
- **New-clone auto-generate flow** — unchanged existing init/update path works when the file is absent after a clone
- **`uninstall` leaves `.gitignore` entry** — no changes to the `uninstall` section; entry persists as intended

## Test Plan
No test suite in this repo — changes are skill markdown. Manual verification:
- [ ] Run `/code-context init` in a fresh project (no `.gitignore`) — verify `.gitignore` is created with `code-context.md`
- [ ] Run `/code-context init` in a project with an existing `.gitignore` that already lists `code-context.md` — verify no duplicate entry
- [ ] Run `/code-context init` in a project where `code-context.md` is committed — verify `git rm --cached` runs and the user sees the commit-reminder warning
- [ ] Run `/code-context init` twice in a row — verify idempotent (no duplicate gitignore lines, no repeated untracking)

## Notes
Phase 3 (review `claude-md-snippet.md`) was verified as a no-op: the snippet only describes read-and-update-in-place behavior and already never references staging or committing. See issue comment.